### PR TITLE
Add support for NodaTime.Duration

### DIFF
--- a/src/MongoDb.Bson.NodaTime/DurationSerializer.cs
+++ b/src/MongoDb.Bson.NodaTime/DurationSerializer.cs
@@ -1,0 +1,11 @@
+﻿using NodaTime;
+using NodaTime.Text;
+
+namespace MongoDb.Bson.NodaTime
+{
+    public class DurationSerializer : PatternSerializer<Duration>
+    {
+        public DurationSerializer() : base(DurationPattern.RoundtripPattern)
+        {}
+    }
+}

--- a/test/MongoDb.Bson.NodaTime.Tests/DurationSerializerTests.cs
+++ b/test/MongoDb.Bson.NodaTime.Tests/DurationSerializerTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using NodaTime;
+using Xunit;
+
+namespace MongoDb.Bson.NodaTime.Tests
+{
+    public class DurationSerializerTests
+    {
+        static DurationSerializerTests()
+        {
+            BsonSerializer.RegisterSerializer(new DurationSerializer());
+        }
+
+        [Fact]
+        public void CanConvertValue()
+        {
+            var obj = new Test { Duration = Duration.FromSeconds(34) };
+            obj.ToTestJson().Should().Contain("'Duration' : '0:00:00:34'");
+
+            obj = BsonSerializer.Deserialize<Test>(obj.ToBson());
+            obj.Duration.Should().Be(obj.Duration);
+        }
+
+
+        [Fact]
+        public void ThrowsWhenValueIsInvalid()
+        {
+            Assert.Throws<FormatException>(() => BsonSerializer.Deserialize<Test>(new BsonDocument(new BsonElement("Duration", "bleh"))));
+        }
+
+        [Fact]
+        public void CanParseNullable()
+        {
+            BsonSerializer.Deserialize<Test>(new BsonDocument(new BsonElement("Duration", BsonNull.Value))).Duration.Should().BeNull();
+        }
+
+        private class Test
+        {
+            public Duration Duration { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
I noticed that you didn't provide support for all NodaTime concepts so I took the liberty of adding support for the `Duration` structure. I used your `PatternSerializer` class together with the `DurationPattern.RoundtripPattern` which I think should do the trick.
