### PR TITLE
Offset serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,8 @@ BsonSerializer.RegisterSerializer(new InstantSerializer());
 
 ```
 
-#Implemented NodaTime Types
+# Implemented NodaTime Types (as of v2.1.0)
 
-(as of v1.3.0)
 * Instant
 * LocalDate
 * LocalTime

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ BsonSerializer.RegisterSerializer(new InstantSerializer());
 * Period
 * Duration
 * ZonedDateTime
+* Offset
 
 # Dependencies
 

--- a/src/MongoDb.Bson.NodaTime/OffsetSerializer.cs
+++ b/src/MongoDb.Bson.NodaTime/OffsetSerializer.cs
@@ -1,0 +1,11 @@
+﻿using NodaTime;
+using NodaTime.Text;
+
+namespace MongoDb.Bson.NodaTime
+{
+    public class OffsetSerializer : PatternSerializer<Offset>
+    {
+        public OffsetSerializer() : base(OffsetPattern.GeneralInvariant)
+        { }
+    }
+}

--- a/test/MongoDb.Bson.NodaTime.Tests/DurationSerializerTests.cs
+++ b/test/MongoDb.Bson.NodaTime.Tests/DurationSerializerTests.cs
@@ -20,8 +20,8 @@ namespace MongoDb.Bson.NodaTime.Tests
             var obj = new Test { Duration = Duration.FromSeconds(34) };
             obj.ToTestJson().Should().Contain("'Duration' : '0:00:00:34'");
 
-            obj = BsonSerializer.Deserialize<Test>(obj.ToBson());
-            obj.Duration.Should().Be(obj.Duration);
+            var deserialized = BsonSerializer.Deserialize<Test>(obj.ToBson());
+            deserialized.Duration.Should().Be(obj.Duration);
         }
 
 

--- a/test/MongoDb.Bson.NodaTime.Tests/LocalDateSerializerTests.cs
+++ b/test/MongoDb.Bson.NodaTime.Tests/LocalDateSerializerTests.cs
@@ -20,8 +20,8 @@ namespace MongoDb.Bson.NodaTime.Tests
             var obj = new Test { LocalDate = new LocalDate(2015, 1, 1) };
             obj.ToTestJson().Should().Contain("'LocalDate' : '2015-01-01'");
 
-            obj = BsonSerializer.Deserialize<Test>(obj.ToBson());
-            obj.LocalDate.Should().Be(obj.LocalDate);
+            var deserialized = BsonSerializer.Deserialize<Test>(obj.ToBson());
+            deserialized.LocalDate.Should().Be(obj.LocalDate);
         }
 
         [Fact]
@@ -30,8 +30,8 @@ namespace MongoDb.Bson.NodaTime.Tests
             var obj = new Test { LocalDate = new LocalDate(2015, 1, 1).WithCalendar(CalendarSystem.PersianSimple) };
             obj.ToTestJson().Should().Contain("'LocalDate' : '2015-01-01'");
 
-            obj = BsonSerializer.Deserialize<Test>(obj.ToBson());
-            obj.LocalDate.Should().Be(obj.LocalDate.WithCalendar(CalendarSystem.Iso));
+            var deserialized = BsonSerializer.Deserialize<Test>(obj.ToBson());
+            deserialized.LocalDate.Should().Be(obj.LocalDate.WithCalendar(CalendarSystem.Iso));
         }
 
         [Fact]

--- a/test/MongoDb.Bson.NodaTime.Tests/LocalDateTimeSerializerTests.cs
+++ b/test/MongoDb.Bson.NodaTime.Tests/LocalDateTimeSerializerTests.cs
@@ -20,8 +20,8 @@ namespace MongoDb.Bson.NodaTime.Tests
             var obj = new Test { LocalDateTime = new LocalDateTime(2015, 1, 2, 3, 4, 5) };
             obj.ToTestJson().Should().Contain("'LocalDateTime' : '2015-01-02T03:04:05'");
 
-            obj = BsonSerializer.Deserialize<Test>(obj.ToBson());
-            obj.LocalDateTime.Should().Be(obj.LocalDateTime);
+            var deserialized = BsonSerializer.Deserialize<Test>(obj.ToBson());
+            deserialized.LocalDateTime.Should().Be(obj.LocalDateTime);
         }
 
 
@@ -31,8 +31,8 @@ namespace MongoDb.Bson.NodaTime.Tests
             var obj = new Test { LocalDateTime = new LocalDateTime(2015, 1, 2, 3, 4, 5).WithCalendar(CalendarSystem.PersianSimple) };
             obj.ToTestJson().Should().Contain("'LocalDateTime' : '2015-01-02T03:04:05'");
 
-            obj = BsonSerializer.Deserialize<Test>(obj.ToBson());
-            obj.LocalDateTime.Should().Be(obj.LocalDateTime.WithCalendar(CalendarSystem.Iso));
+            var deserialized = BsonSerializer.Deserialize<Test>(obj.ToBson());
+            deserialized.LocalDateTime.Should().Be(obj.LocalDateTime.WithCalendar(CalendarSystem.Iso));
         }
 
         [Fact]

--- a/test/MongoDb.Bson.NodaTime.Tests/LocalTimeSerializerTests.cs
+++ b/test/MongoDb.Bson.NodaTime.Tests/LocalTimeSerializerTests.cs
@@ -20,8 +20,8 @@ namespace MongoDb.Bson.NodaTime.Tests
             var obj = new Test { LocalTime = new LocalTime(13, 25, 1) };
             obj.ToTestJson().Should().Contain("'LocalTime' : '13:25:01'");
 
-            obj = BsonSerializer.Deserialize<Test>(obj.ToBson());
-            obj.LocalTime.Should().Be(obj.LocalTime);
+            var deserialized = BsonSerializer.Deserialize<Test>(obj.ToBson());
+            deserialized.LocalTime.Should().Be(obj.LocalTime);
         }
 
         [Fact]

--- a/test/MongoDb.Bson.NodaTime.Tests/OffsetDateTimeSerializer.cs
+++ b/test/MongoDb.Bson.NodaTime.Tests/OffsetDateTimeSerializer.cs
@@ -20,8 +20,8 @@ namespace MongoDb.Bson.NodaTime.Tests
             var obj = new Test { OffsetDateTime = new LocalDateTime(2015, 1, 2, 3, 4, 5).WithOffset(Offset.FromHours(1)) };
             obj.ToTestJson().Should().Contain("'OffsetDateTime' : '2015-01-02T03:04:05+01'");
 
-            obj = BsonSerializer.Deserialize<Test>(obj.ToBson());
-            obj.OffsetDateTime.Should().Be(obj.OffsetDateTime);
+            var deserialized = BsonSerializer.Deserialize<Test>(obj.ToBson());
+            deserialized.OffsetDateTime.Should().Be(obj.OffsetDateTime);
         }
 
 
@@ -31,8 +31,8 @@ namespace MongoDb.Bson.NodaTime.Tests
             var obj = new Test { OffsetDateTime = new LocalDateTime(2015, 1, 2, 3, 4, 5).WithOffset(Offset.FromHours(1)).WithCalendar(CalendarSystem.PersianSimple) };
             obj.ToTestJson().Should().Contain("'OffsetDateTime' : '2015-01-02T03:04:05+01'");
 
-            obj = BsonSerializer.Deserialize<Test>(obj.ToBson());
-            obj.OffsetDateTime.Should().Be(obj.OffsetDateTime.WithCalendar(CalendarSystem.Iso));
+            var deserialized = BsonSerializer.Deserialize<Test>(obj.ToBson());
+            deserialized.OffsetDateTime.Should().Be(obj.OffsetDateTime.WithCalendar(CalendarSystem.Iso));
         }
 
         [Fact]

--- a/test/MongoDb.Bson.NodaTime.Tests/OffsetSerializerTests.cs
+++ b/test/MongoDb.Bson.NodaTime.Tests/OffsetSerializerTests.cs
@@ -1,0 +1,45 @@
+﻿using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using NodaTime;
+using System;
+using Xunit;
+
+namespace MongoDb.Bson.NodaTime.Tests
+{
+    public class OffsetSerializerTests
+    {
+        static OffsetSerializerTests()
+        {
+            BsonSerializer.RegisterSerializer(new OffsetSerializer());
+        }
+
+        [Fact]
+        public void CanConvertValue()
+        {
+            var obj = new Test { Offset = Offset.FromHours(4) };
+            obj.ToTestJson().Should().Contain("'Offset' : '+04'");
+
+            var deserialized = BsonSerializer.Deserialize<Test>(obj.ToBson());
+            deserialized.Offset.Should().Be(obj.Offset);
+        }
+
+        [Fact]
+        public void ThrowsWhenValueIsInvalid()
+        {
+            Assert.Throws<FormatException>(() => BsonSerializer.Deserialize<Test>(new BsonDocument(new BsonElement("Duration", "bleh"))));
+        }
+
+        [Fact]
+        public void CanParseNullable()
+        {
+            BsonSerializer.Deserialize<Test>(new BsonDocument(new BsonElement("OffsetNullable", BsonNull.Value))).OffsetNullable.Should().BeNull();
+        }
+
+        private class Test
+        {
+            public Offset Offset { get; set; }
+            public Offset? OffsetNullable { get; set; }
+        }
+    }
+}

--- a/test/MongoDb.Bson.NodaTime.Tests/PeriodSerializerTests.cs
+++ b/test/MongoDb.Bson.NodaTime.Tests/PeriodSerializerTests.cs
@@ -20,8 +20,8 @@ namespace MongoDb.Bson.NodaTime.Tests
             var obj = new Test { Period = Period.FromSeconds(34) };
             obj.ToTestJson().Should().Contain("'Period' : 'PT34S'");
 
-            obj = BsonSerializer.Deserialize<Test>(obj.ToBson());
-            obj.Period.Should().Be(obj.Period);
+            var deserialized = BsonSerializer.Deserialize<Test>(obj.ToBson());
+            deserialized.Period.Should().Be(obj.Period);
         }
 
 

--- a/test/MongoDb.Bson.NodaTime.Tests/ZonedDateTimeSerializerTests.cs
+++ b/test/MongoDb.Bson.NodaTime.Tests/ZonedDateTimeSerializerTests.cs
@@ -22,10 +22,10 @@ namespace MongoDb.Bson.NodaTime.Tests
             var obj = new Test { ZonedDateTime = dateTime };
             obj.ToTestJson().Should().Contain("'ZonedDateTime' : '2015-01-01T22:04:05 America/New_York (-05)'");
 
-            obj = BsonSerializer.Deserialize<Test>(obj.ToBson());
-            obj.ZonedDateTime.Should().Be(obj.ZonedDateTime);
-            obj.ZonedDateTime.Should().Be(dateTime);
-            obj.ZonedDateTime.Zone.Should().Be(easternTimezone);
+            var deserialized = BsonSerializer.Deserialize<Test>(obj.ToBson());
+            deserialized.ZonedDateTime.Should().Be(obj.ZonedDateTime);
+            deserialized.ZonedDateTime.Should().Be(dateTime);
+            deserialized.ZonedDateTime.Zone.Should().Be(easternTimezone);
         }
 
         [Fact]
@@ -35,10 +35,10 @@ namespace MongoDb.Bson.NodaTime.Tests
             var obj = new Test { ZonedDateTime = dateTime };
             obj.ToTestJson().Should().Contain("'ZonedDateTime' : '2015-01-02T03:04:05 UTC (+00)'");
 
-            obj = BsonSerializer.Deserialize<Test>(obj.ToBson());
-            obj.ZonedDateTime.Should().Be(obj.ZonedDateTime);
-            obj.ZonedDateTime.Should().Be(dateTime);
-            obj.ZonedDateTime.Zone.Should().Be(DateTimeZone.Utc);
+            var deserialized = BsonSerializer.Deserialize<Test>(obj.ToBson());
+            deserialized.ZonedDateTime.Should().Be(obj.ZonedDateTime);
+            deserialized.ZonedDateTime.Should().Be(dateTime);
+            deserialized.ZonedDateTime.Zone.Should().Be(DateTimeZone.Utc);
         }
 
         [Fact]


### PR DESCRIPTION
Adds support for Offset. Based on the example of `DurationSerializer.cs` as proposed in https://github.com/AndyBeverlySchool/MongoDb.Bson.NodaTime/issues/10.

I also noticed that some tests assert obj to itself like `obj.LocalDate.Should().Be(obj.LocalDate)`.  It seems not intended, so I added a fix in a separate commit.

Please review :)