### PR TITLE
Fix build (remove preview dependencies)

### DIFF
--- a/test/MongoDb.Bson.NodaTime.Tests/MongoDb.Bson.NodaTime.Tests.csproj
+++ b/test/MongoDb.Bson.NodaTime.Tests/MongoDb.Bson.NodaTime.Tests.csproj
@@ -16,9 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-*" />
-    <PackageReference Include="xunit" Version="2.3.0-*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="xunit" Version="2.3.0" />
     <PackageReference Include="FluentAssertions" Version="4.16.0" />
     <PackageReference Include="NodaTime.Testing" Version="2.2.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.3.0" />


### PR DESCRIPTION
Somehow AppVeyor build doesn't work anymore with current dependencies:
```
C:\projects\mongodb-bson-nodatime\test\MongoDb.Bson.NodaTime.Tests\MongoDb.Bson.NodaTime.Tests.csproj : error NU1605: Detected package downgrade: Microsoft.NET.Test.Sdk from 15.0.0 to 15.0.0-preview-20170106-08. Reference the package directly from the project to select a different version.  [C:\projects\mongodb-bson-nodatime\MongoDb.Bson.NodaTime.sln]
C:\projects\mongodb-bson-nodatime\test\MongoDb.Bson.NodaTime.Tests\MongoDb.Bson.NodaTime.Tests.csproj : error NU1605:  MongoDb.Bson.NodaTime.Tests -> xunit.runner.visualstudio 2.3.0 -> Microsoft.NET.Test.Sdk (>= 15.0.0)  [C:\projects\mongodb-bson-nodatime\MongoDb.Bson.NodaTime.sln]
C:\projects\mongodb-bson-nodatime\test\MongoDb.Bson.NodaTime.Tests\MongoDb.Bson.NodaTime.Tests.csproj : error NU1605:  MongoDb.Bson.NodaTime.Tests -> Microsoft.NET.Test.Sdk (>= 15.0.0-preview-20170106-08) [C:\projects\mongodb-bson-nodatime\MongoDb.Bson.NodaTime.sln]
```
So I deleted -preview suffix.

(When I tested the previous PR I thought that issue of my environment, because I also had to change the target framework to one installed to be able to run tests). 