### PR TITLE
use patternserializer for instants

### DIFF
--- a/src/MongoDb.Bson.NodaTime/InstantSerializer.cs
+++ b/src/MongoDb.Bson.NodaTime/InstantSerializer.cs
@@ -1,33 +1,13 @@
-﻿using System;
-using MongoDB.Bson;
-using MongoDB.Bson.Serialization;
-using MongoDB.Bson.Serialization.Serializers;
-using NodaTime;
+﻿using NodaTime;
 using NodaTime.Text;
 
 namespace MongoDb.Bson.NodaTime
 {
-    public class InstantSerializer : SerializerBase<Instant>
+    public class InstantSerializer : PatternSerializer<Instant>
     {
-        public override Instant Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+        public InstantSerializer() 
+            : base(InstantPattern.ExtendedIso)
         {
-            var type = context.Reader.GetCurrentBsonType();
-            switch (type)
-            {
-                case BsonType.DateTime:
-                    return Instant.FromUnixTimeMilliseconds(context.Reader.ReadDateTime());
-                case BsonType.String:
-                    return InstantPattern.ExtendedIso.CheckedParse(context.Reader.ReadString());
-                case BsonType.Null:
-                    throw new InvalidOperationException("Instant is a value type, but the BsonValue is null.");
-                default:
-                    throw new NotSupportedException($"Cannot convert a {type} to an Instant.");
-            }
-        }
-
-        public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, Instant value)
-        {
-            context.Writer.WriteDateTime(value.ToUnixTimeTicks() / NodaConstants.TicksPerMillisecond);
         }
     }
 }

--- a/test/MongoDb.Bson.NodaTime.Tests/InstantSerializerTests.cs
+++ b/test/MongoDb.Bson.NodaTime.Tests/InstantSerializerTests.cs
@@ -15,11 +15,22 @@ namespace MongoDb.Bson.NodaTime.Tests
         }
 
         [Fact]
+        public void CanConvertTicksValid()
+        {
+            var instant = Instant.FromUtc(2015, 1, 1, 0, 0, 1).PlusTicks(1_234_567);
+            var obj = new Test { Instant = instant };
+            obj.ToTestJson().Should().Contain("'Instant' : '2015-01-01T00:00:01.1234567Z'");
+
+            obj = BsonSerializer.Deserialize<Test>(obj.ToBson());
+            obj.Instant.Should().Be(instant);
+        }
+
+        [Fact]
         public void CanConvertValid()
         {
             var instant = Instant.FromUtc(2015, 1, 1, 0, 0, 1);
             var obj = new Test { Instant = instant };
-            obj.ToTestJson().Should().Contain("'Instant' : ISODate('2015-01-01T00:00:01Z')");
+            obj.ToTestJson().Should().Contain("'Instant' : '2015-01-01T00:00:01Z'");
 
             obj = BsonSerializer.Deserialize<Test>(obj.ToBson());
             obj.Instant.Should().Be(instant);
@@ -30,7 +41,7 @@ namespace MongoDb.Bson.NodaTime.Tests
         {
             var instant = Instant.FromUtc(2015, 1, 1, 0, 0, 1);
             var obj = new Test { InstantNullable = instant };
-            obj.ToTestJson().Should().Contain("'InstantNullable' : ISODate('2015-01-01T00:00:01Z')");
+            obj.ToTestJson().Should().Contain("'InstantNullable' : '2015-01-01T00:00:01Z'");
 
             obj = BsonSerializer.Deserialize<Test>(obj.ToBson());
             obj.InstantNullable.Should().Be(instant);
@@ -41,7 +52,7 @@ namespace MongoDb.Bson.NodaTime.Tests
         {
             var instant = Instant.FromUtc(2015, 1, 1, 0, 0, 1);
             var obj = new Test { Instant = instant };
-            obj.ToTestJson().Should().Contain("'Instant' : ISODate('2015-01-01T00:00:01Z')");
+            obj.ToTestJson().Should().Contain("'Instant' : '2015-01-01T00:00:01Z'");
             obj.ToTestJson().Should().Contain("'InstantNullable' : null");
 
             obj = BsonSerializer.Deserialize<Test>(obj.ToBson());


### PR DESCRIPTION
This is a PR for #14 

The instant serializer now also uses the PatternSerializer as base class with the ExtendendIso pattern to store it. this ensures that the precision is not lost while storing and ticks don't get lost