### PR TITLE
Upgrade MongoDB.Bson package to version 2.28.0

### DIFF
--- a/.idea/.idea.MongoDb.Bson.NodaTime/.idea/.gitignore
+++ b/.idea/.idea.MongoDb.Bson.NodaTime/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/modules.xml
+/contentModel.xml
+/projectSettingsUpdater.xml
+/.idea.MongoDb.Bson.NodaTime.iml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.MongoDb.Bson.NodaTime/.idea/encodings.xml
+++ b/.idea/.idea.MongoDb.Bson.NodaTime/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/MongoDb.Bson.NodaTime.sln
+++ b/MongoDb.Bson.NodaTime.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
 		README.md = README.md
+		appveyor.yml = appveyor.yml
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MongoDb.Bson.NodaTime", "src\MongoDb.Bson.NodaTime\MongoDb.Bson.NodaTime.csproj", "{C48D14DC-61D4-4F5E-B8B4-0E7A7E3855ED}"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.0.0-{build}
+version: 3.1.0-{build}
 os: Ubuntu2004
 before_build:
 - dotnet restore --use-lock-file

--- a/src/MongoDb.Bson.NodaTime/MongoDb.Bson.NodaTime.csproj
+++ b/src/MongoDb.Bson.NodaTime/MongoDb.Bson.NodaTime.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>MongoDb.Bson.NodaTime</AssemblyTitle>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Greg Lincoln</Authors>
-    <TargetFrameworks>netstandard2</TargetFrameworks>
+    <TargetFramework>netstandard2</TargetFramework>
     <AssemblyName>MongoDb.Bson.NodaTime</AssemblyName>
     <PackageId>MongoDb.Bson.NodaTime</PackageId>
     <PackageTags>nodatime;bson;mongodb;mongo</PackageTags>
@@ -17,8 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Bson" Version="2.13.1" />
-    <PackageReference Include="NodaTime" Version="3.0.6" />
+    <PackageReference Include="MongoDB.Bson" Version="2.28.0" />
+    <PackageReference Include="NodaTime" Version="3.1.12" />
   </ItemGroup>
 
 </Project>

--- a/src/MongoDb.Bson.NodaTime/packages.lock.json
+++ b/src/MongoDb.Bson.NodaTime/packages.lock.json
@@ -4,10 +4,11 @@
     ".NETStandard,Version=v2.0": {
       "MongoDB.Bson": {
         "type": "Direct",
-        "requested": "[2.13.1, )",
-        "resolved": "2.13.1",
-        "contentHash": "B/AI2we7YwfFuNcXr4jlCnVI5dJp+g8vkyj3Shi/bOpGhZQaxW4jK/NiiTwYvqxaMOe4MtVR+6Zlk4D2zalC7A==",
+        "requested": "[2.28.0, )",
+        "resolved": "2.28.0",
+        "contentHash": "yiWN3scVV0lYpFXn1CL4PB0BK3KrHFC44qw72+/cBIDS9+r9MQYfxFMxM+pAvnSssAZtQ7ZabCu7z3UOXqKy4w==",
         "dependencies": {
+          "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "5.0.0"
         }
       },
@@ -22,9 +23,9 @@
       },
       "NodaTime": {
         "type": "Direct",
-        "requested": "[3.0.6, )",
-        "resolved": "3.0.6",
-        "contentHash": "Jt+qjGV7YW3HoYAT4/MTKGI5+mw6hS+mqOr33hJB/NSacdO0QK2tnSTcmqtv7S3kgl7hYUfN/qaYW70D+o9tpQ==",
+        "requested": "[3.1.12, )",
+        "resolved": "3.1.12",
+        "contentHash": "nDcUbG0jiEXmV8cOz7V8GnUKlmPJjqZm/R+E2JNnUSdlMoaQ19xSU8GXFLReGs/Nt8xdBfA8XfO77xVboWO1Vg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "4.7.1"
         }
@@ -33,6 +34,26 @@
         "type": "Transitive",
         "resolved": "1.1.0",
         "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.5.1",
+        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.5",
+        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Numerics.Vectors": "4.4.0",
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "System.Numerics.Vectors": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "UiLzLW+Lw6HLed1Hcg+8jSRttrbuXv7DANVj0DkL9g6EnnzbL75EB7EWsw5uRbhxd/4YdG8li5XizGWepmG3PQ=="
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",

--- a/test/MongoDb.Bson.NodaTime.Tests/packages.lock.json
+++ b/test/MongoDb.Bson.NodaTime.Tests/packages.lock.json
@@ -174,9 +174,10 @@
       },
       "MongoDB.Bson": {
         "type": "Transitive",
-        "resolved": "2.13.1",
-        "contentHash": "B/AI2we7YwfFuNcXr4jlCnVI5dJp+g8vkyj3Shi/bOpGhZQaxW4jK/NiiTwYvqxaMOe4MtVR+6Zlk4D2zalC7A==",
+        "resolved": "2.28.0",
+        "contentHash": "yiWN3scVV0lYpFXn1CL4PB0BK3KrHFC44qw72+/cBIDS9+r9MQYfxFMxM+pAvnSssAZtQ7ZabCu7z3UOXqKy4w==",
         "dependencies": {
+          "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "5.0.0"
         }
       },
@@ -262,8 +263,8 @@
       },
       "NodaTime": {
         "type": "Transitive",
-        "resolved": "3.0.6",
-        "contentHash": "Jt+qjGV7YW3HoYAT4/MTKGI5+mw6hS+mqOr33hJB/NSacdO0QK2tnSTcmqtv7S3kgl7hYUfN/qaYW70D+o9tpQ==",
+        "resolved": "3.1.12",
+        "contentHash": "nDcUbG0jiEXmV8cOz7V8GnUKlmPJjqZm/R+E2JNnUSdlMoaQ19xSU8GXFLReGs/Nt8xdBfA8XfO77xVboWO1Vg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "4.7.1"
         }
@@ -790,6 +791,11 @@
           "System.Runtime.Extensions": "4.3.0",
           "System.Threading": "4.3.0"
         }
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.5",
+        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw=="
       },
       "System.Net.Http": {
         "type": "Transitive",
@@ -1496,8 +1502,8 @@
       "mongodb.bson.nodatime": {
         "type": "Project",
         "dependencies": {
-          "MongoDB.Bson": "2.13.1",
-          "NodaTime": "3.0.6"
+          "MongoDB.Bson": "[2.28.0, )",
+          "NodaTime": "[3.1.12, )"
         }
       }
     },


### PR DESCRIPTION
Upgraded the MongoDB.Bson package to the latest version (2.28.0) to ensure compatibility with the latest features and improvements. This update addresses several issues and enhancements, including strong naming support as discussed in the MongoDB community forums.

Reference: https://www.mongodb.com/community/forums/t/net-c-driver-strong-naming/291649/22